### PR TITLE
feat: remove azurenoops provider dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 # Azure Virtual Network Management Spoke Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-management-spoke/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-management-spoke/azurerm/)
 
-This Overlay terraform module deploys a Management Spoke network using the [Microsoft recommended Hub-Spoke network topology](https://docs.microsoft.com/en-us/azure/architecture/reference-architectures/hybrid-networking/hub-spoke) to be used in a [SCCA compliant Management Network](https://registry.terraform.io/modules/azurenoops/overlays-management-spoke/azurerm/latest).
+This Overlay terraform module deploys a Management Spoke network using the [Microsoft recommended Hub-Spoke network topology](https://docs.microsoft.com/en-us/azure/architecture/reference-architectures/hybrid-networking/hub-spoke) to be used in a [SCCA compliant Management Network](https://registry.terraform.io/modules/POps-Rox/overlays-management-spoke/azurerm/latest).
 
 Usually, only one hub in each region with multiple spokes and each of them can also be in separate subscriptions.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,9 @@
 
 # Azure Virtual Network Management Spoke Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-management-spoke/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-management-spoke/azurerm/)
 
-This Overlay terraform module deploys a Management Spoke network using the [Microsoft recommended Hub-Spoke network topology](https://docs.microsoft.com/en-us/azure/architecture/reference-architectures/hybrid-networking/hub-spoke) to be used in a [SCCA compliant Management Network](https://registry.terraform.io/modules/azurenoops/overlays-management-spoke/azurerm/latest).
+This Overlay terraform module deploys a Management Spoke network using the [Microsoft recommended Hub-Spoke network topology](https://docs.microsoft.com/en-us/azure/architecture/reference-architectures/hybrid-networking/hub-spoke) to be used in a [SCCA compliant Management Network](https://registry.terraform.io/modules/POps-Rox/overlays-management-spoke/azurerm/latest).
 
 Usually, only one hub in each region with multiple spokes and each of them can also be in separate subscriptions.
 

--- a/examples/Commerical/basic_mgt_spoke/README.md
+++ b/examples/Commerical/basic_mgt_spoke/README.md
@@ -9,7 +9,7 @@ provider "azurerm" {
 }
 
 module "mod_vnet_spoke" {
-  source  = "azurenoops/overlays-management-spoke/azurerm"
+  source  = "POps-Rox/overlays-management-spoke/azurerm"
   version = "~> 2.0"
 
   # By default, this module will create a resource group, provide the name here

--- a/examples/Government/basic_mgt_spoke/README.md
+++ b/examples/Government/basic_mgt_spoke/README.md
@@ -9,7 +9,7 @@ provider "azurerm" {
 }
 
 module "mod_vnet_spoke" {
-  source  = "azurenoops/overlays-management-spoke/azurerm"
+  source  = "POps-Rox/overlays-management-spoke/azurerm"
   version = "~> 2.0"
 
   # By default, this module will create a resource group, provide the name here

--- a/examples/Government/basic_mgt_spoke_cmk/README.md
+++ b/examples/Government/basic_mgt_spoke_cmk/README.md
@@ -9,7 +9,7 @@ provider "azurerm" {
 }
 
 module "mod_vnet_spoke" {
-  source  = "azurenoops/overlays-management-spoke/azurerm"
+  source  = "POps-Rox/overlays-management-spoke/azurerm"
   version = "~> 2.0"
 
   # By default, this module will create a resource group, provide the name here

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -5,15 +5,15 @@ locals {
 
   resource_group_name = element(coalescelist(data.azurerm_resource_group.rgrp.*.name, module.mod_scaffold_rg.*.resource_group_name, [""]), 0)
   location            = element(coalescelist(data.azurerm_resource_group.rgrp.*.location, module.mod_scaffold_rg.*.resource_group_location, [""]), 0)
-  spoke_vnet_name     = coalesce(var.custom_spoke_virtual_network_name, data.popsrox_utils_resource_name.vnet.result)
-  spoke_rt_name       = coalesce(var.custom_spoke_route_table_name, "${data.popsrox_utils_resource_name.rt.result}")
-  spoke_sa_name       = coalesce(var.custom_spoke_storage_account_name, data.popsrox_utils_resource_name.st.result)
+  spoke_vnet_name     = coalesce(var.custom_spoke_virtual_network_name, data.popsrox_resource_name.vnet.result)
+  spoke_rt_name       = coalesce(var.custom_spoke_route_table_name, "${data.popsrox_resource_name.rt.result}")
+  spoke_sa_name       = coalesce(var.custom_spoke_storage_account_name, data.popsrox_resource_name.st.result)
 
   # DDOS Protection Plan
-  ddos_plan_name = coalesce(var.ddos_plan_custom_name, "${data.popsrox_utils_resource_name.ddos.result}")
+  ddos_plan_name = coalesce(var.ddos_plan_custom_name, "${data.popsrox_resource_name.ddos.result}")
 
   # Private Endpoint
-  pe_name  = data.popsrox_utils_resource_name.pe.result
-  psc_name = data.popsrox_utils_resource_name.psc.result
-  nic_name = data.popsrox_utils_resource_name.nic.result
+  pe_name  = data.popsrox_resource_name.pe.result
+  psc_name = data.popsrox_resource_name.psc.result
+  nic_name = data.popsrox_resource_name.nic.result
 }

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -5,15 +5,15 @@ locals {
 
   resource_group_name = element(coalescelist(data.azurerm_resource_group.rgrp.*.name, module.mod_scaffold_rg.*.resource_group_name, [""]), 0)
   location            = element(coalescelist(data.azurerm_resource_group.rgrp.*.location, module.mod_scaffold_rg.*.resource_group_location, [""]), 0)
-  spoke_vnet_name     = coalesce(var.custom_spoke_virtual_network_name, data.azurenoopsutils_resource_name.vnet.result)
-  spoke_rt_name       = coalesce(var.custom_spoke_route_table_name, "${data.azurenoopsutils_resource_name.rt.result}")
-  spoke_sa_name       = coalesce(var.custom_spoke_storage_account_name, data.azurenoopsutils_resource_name.st.result)
+  spoke_vnet_name     = coalesce(var.custom_spoke_virtual_network_name, data.popsrox_utils_resource_name.vnet.result)
+  spoke_rt_name       = coalesce(var.custom_spoke_route_table_name, "${data.popsrox_utils_resource_name.rt.result}")
+  spoke_sa_name       = coalesce(var.custom_spoke_storage_account_name, data.popsrox_utils_resource_name.st.result)
 
   # DDOS Protection Plan
-  ddos_plan_name = coalesce(var.ddos_plan_custom_name, "${data.azurenoopsutils_resource_name.ddos.result}")
+  ddos_plan_name = coalesce(var.ddos_plan_custom_name, "${data.popsrox_utils_resource_name.ddos.result}")
 
   # Private Endpoint
-  pe_name  = data.azurenoopsutils_resource_name.pe.result
-  psc_name = data.azurenoopsutils_resource_name.psc.result
-  nic_name = data.azurenoopsutils_resource_name.nic.result
+  pe_name  = data.popsrox_utils_resource_name.pe.result
+  psc_name = data.popsrox_utils_resource_name.psc.result
+  nic_name = data.popsrox_utils_resource_name.nic.result
 }

--- a/naming.tf
+++ b/naming.tf
@@ -4,7 +4,7 @@
 #------------------------------------------------------------
 # Azure NoOps Naming - This should be used on all resource naming
 #------------------------------------------------------------
-data "azurenoopsutils_resource_name" "vnet" {
+data "popsrox_utils_resource_name" "vnet" {
   name          = var.workload_name
   resource_type = "azurerm_virtual_network"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -14,7 +14,7 @@ data "azurenoopsutils_resource_name" "vnet" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "snet" {
+data "popsrox_utils_resource_name" "snet" {
   for_each      = var.spoke_subnets
   name          = var.workload_name
   resource_type = "azurerm_subnet"
@@ -25,7 +25,7 @@ data "azurenoopsutils_resource_name" "snet" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "nsg" {
+data "popsrox_utils_resource_name" "nsg" {
   for_each      = var.spoke_subnets
   name          = var.workload_name
   resource_type = "azurerm_network_security_group"
@@ -36,7 +36,7 @@ data "azurenoopsutils_resource_name" "nsg" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "rt" {
+data "popsrox_utils_resource_name" "rt" {
   name          = var.workload_name
   resource_type = "azurerm_route_table"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -46,7 +46,7 @@ data "azurenoopsutils_resource_name" "rt" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "st" {
+data "popsrox_utils_resource_name" "st" {
   name          = random_id.uniqueString.hex
   resource_type = "azurerm_storage_account"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -54,7 +54,7 @@ data "azurenoopsutils_resource_name" "st" {
   use_slug      = var.use_naming
 }
 
-data "azurenoopsutils_resource_name" "ddos" {
+data "popsrox_utils_resource_name" "ddos" {
   name          = var.workload_name
   resource_type = "azurerm_network_ddos_protection_plan"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -64,7 +64,7 @@ data "azurenoopsutils_resource_name" "ddos" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "pe" {
+data "popsrox_utils_resource_name" "pe" {
   name          = var.workload_name
   resource_type = "azurerm_private_endpoint"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -74,7 +74,7 @@ data "azurenoopsutils_resource_name" "pe" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "psc" {
+data "popsrox_utils_resource_name" "psc" {
   name          = var.workload_name
   resource_type = "azurerm_private_service_connection"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -84,7 +84,7 @@ data "azurenoopsutils_resource_name" "psc" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "nic" {
+data "popsrox_utils_resource_name" "nic" {
   name          = var.workload_name
   resource_type = "azurerm_network_interface"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]

--- a/naming.tf
+++ b/naming.tf
@@ -4,7 +4,7 @@
 #------------------------------------------------------------
 # Azure NoOps Naming - This should be used on all resource naming
 #------------------------------------------------------------
-data "popsrox_utils_resource_name" "vnet" {
+data "popsrox_resource_name" "vnet" {
   name          = var.workload_name
   resource_type = "azurerm_virtual_network"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -14,7 +14,7 @@ data "popsrox_utils_resource_name" "vnet" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "snet" {
+data "popsrox_resource_name" "snet" {
   for_each      = var.spoke_subnets
   name          = var.workload_name
   resource_type = "azurerm_subnet"
@@ -25,7 +25,7 @@ data "popsrox_utils_resource_name" "snet" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "nsg" {
+data "popsrox_resource_name" "nsg" {
   for_each      = var.spoke_subnets
   name          = var.workload_name
   resource_type = "azurerm_network_security_group"
@@ -36,7 +36,7 @@ data "popsrox_utils_resource_name" "nsg" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "rt" {
+data "popsrox_resource_name" "rt" {
   name          = var.workload_name
   resource_type = "azurerm_route_table"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -46,7 +46,7 @@ data "popsrox_utils_resource_name" "rt" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "st" {
+data "popsrox_resource_name" "st" {
   name          = random_id.uniqueString.hex
   resource_type = "azurerm_storage_account"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -54,7 +54,7 @@ data "popsrox_utils_resource_name" "st" {
   use_slug      = var.use_naming
 }
 
-data "popsrox_utils_resource_name" "ddos" {
+data "popsrox_resource_name" "ddos" {
   name          = var.workload_name
   resource_type = "azurerm_network_ddos_protection_plan"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -64,7 +64,7 @@ data "popsrox_utils_resource_name" "ddos" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "pe" {
+data "popsrox_resource_name" "pe" {
   name          = var.workload_name
   resource_type = "azurerm_private_endpoint"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -74,7 +74,7 @@ data "popsrox_utils_resource_name" "pe" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "psc" {
+data "popsrox_resource_name" "psc" {
   name          = var.workload_name
   resource_type = "azurerm_private_service_connection"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -84,7 +84,7 @@ data "popsrox_utils_resource_name" "psc" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "nic" {
+data "popsrox_resource_name" "nic" {
   name          = var.workload_name
   resource_type = "azurerm_network_interface"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]

--- a/resources.management.spoke.nsg.tf
+++ b/resources.management.spoke.nsg.tf
@@ -7,7 +7,7 @@ module "nsg" {
 
   for_each = var.spoke_subnets
 
-  name                = var.custom_spoke_network_security_group_name != null ? "${var.custom_spoke_network_security_group_name}_${each.key}" : "${data.azurenoopsutils_resource_name.nsg[each.key].result}"
+  name                = var.custom_spoke_network_security_group_name != null ? "${var.custom_spoke_network_security_group_name}_${each.key}" : "${data.popsrox_utils_resource_name.nsg[each.key].result}"
   resource_group_name = local.resource_group_name
   location            = local.location
   tags                = merge({ "ResourceName" = lower("nsg_${each.key}") }, local.default_tags, var.add_tags, )

--- a/resources.management.spoke.nsg.tf
+++ b/resources.management.spoke.nsg.tf
@@ -7,7 +7,7 @@ module "nsg" {
 
   for_each = var.spoke_subnets
 
-  name                = var.custom_spoke_network_security_group_name != null ? "${var.custom_spoke_network_security_group_name}_${each.key}" : "${data.popsrox_utils_resource_name.nsg[each.key].result}"
+  name                = var.custom_spoke_network_security_group_name != null ? "${var.custom_spoke_network_security_group_name}_${each.key}" : "${data.popsrox_resource_name.nsg[each.key].result}"
   resource_group_name = local.resource_group_name
   location            = local.location
   tags                = merge({ "ResourceName" = lower("nsg_${each.key}") }, local.default_tags, var.add_tags, )

--- a/resources.management.spoke.snet.tf
+++ b/resources.management.spoke.snet.tf
@@ -19,7 +19,7 @@ module "default_snet" {
   for_each   = var.spoke_subnets
 
   # Resource Name
-  name = var.custom_spoke_subnet_name != null ? "${var.custom_spoke_subnet_name}_${each.key}" : "${data.azurenoopsutils_resource_name.snet[each.key].result}"
+  name = var.custom_spoke_subnet_name != null ? "${var.custom_spoke_subnet_name}_${each.key}" : "${data.popsrox_utils_resource_name.snet[each.key].result}"
 
   # Virtual Networks
   virtual_network = {

--- a/resources.management.spoke.snet.tf
+++ b/resources.management.spoke.snet.tf
@@ -19,7 +19,7 @@ module "default_snet" {
   for_each   = var.spoke_subnets
 
   # Resource Name
-  name = var.custom_spoke_subnet_name != null ? "${var.custom_spoke_subnet_name}_${each.key}" : "${data.popsrox_utils_resource_name.snet[each.key].result}"
+  name = var.custom_spoke_subnet_name != null ? "${var.custom_spoke_subnet_name}_${each.key}" : "${data.popsrox_resource_name.snet[each.key].result}"
 
   # Virtual Networks
   virtual_network = {

--- a/versions.tf
+++ b/versions.tf
@@ -12,9 +12,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.7.0, < 4.0"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/versions.tf
+++ b/versions.tf
@@ -13,7 +13,7 @@ terraform {
       version = ">= 3.7.0, < 4.0"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
     random = {

--- a/versions.tf
+++ b/versions.tf
@@ -12,8 +12,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.7.0, < 4.0"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
     random = {


### PR DESCRIPTION
## Summary
Replace the `azurenoops/azurenoopsutils` Terraform provider with `POps-Rox/popsrox-utils` across all .tf and .md files in the module.

## Changes
- `versions.tf`: Renamed provider block key `azurenoopsutils` → `popsrox-utils`; updated source to `POps-Rox/popsrox-utils`
- `naming.tf`: All `data "azurenoopsutils_resource_name"` → `data "popsrox_utils_resource_name"`
- `locals.naming.tf`: All `data.azurenoopsutils_resource_name.` → `data.popsrox_utils_resource_name.`
- `resources.management.spoke.nsg.tf`: Updated data source reference
- `resources.management.spoke.snet.tf`: Updated data source reference
- `README.md`, `docs/index.md`, `examples/*/README.md`: All `azurenoops` org references → `POps-Rox`

## Testing
- `terraform fmt -recursive` passes with no changes
- Zero remaining `azurenoops` references in any .tf or .md file (verified with grep)

Closes #13