### PR TITLE
fix: correct truncated module source slugs (tf-az-overlays → terraform-az-overlays)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,10 +1,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: tf-az-overlays-managementspoke
+  name: terraform-az-overlays-managementspoke
   description: Terraform overlay module for management spoke virtual networks
   annotations:
-    github.com/project-slug: POps-Rox/tf-az-overlays-managementspoke
+    github.com/project-slug: POps-Rox/terraform-az-overlays-managementspoke
     backstage.io/techdocs-ref: dir:.
   tags:
     - terraform
@@ -12,7 +12,7 @@ metadata:
     - azure
     - platform-ops
   links:
-    - url: https://github.com/POps-Rox/tf-az-overlays-managementspoke
+    - url: https://github.com/POps-Rox/terraform-az-overlays-managementspoke
       title: GitHub Repository
       icon: github
 spec:

--- a/examples/Commerical/basic_mgt_spoke/main.tf
+++ b/examples/Commerical/basic_mgt_spoke/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_vnet_spoke" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-managementspoke"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-managementspoke"
   #version = "~> x.x.x"
   source = "../../.."
 
@@ -57,7 +57,7 @@ module "mod_vnet_spoke" {
 
 # Create VNet Peering between Hub and Identity VNets
 module "mod_hub_to_id_vnet_peering" {
-  source = "github.com/POps-Rox/tf-az-overlays-vnetpeering"
+  source = "github.com/POps-Rox/terraform-az-overlays-vnetpeering"
 
   location           = var.default_location
   deploy_environment = var.deploy_environment

--- a/examples/Government/basic_mgt_spoke/main.tf
+++ b/examples/Government/basic_mgt_spoke/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_vnet_spoke" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-managementspoke"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-managementspoke"
   #version = "~> x.x.x"
   source = "../../.."
 
@@ -55,7 +55,7 @@ module "mod_vnet_spoke" {
 
 # Create VNet Peering between Hub and Identity VNets
 module "mod_hub_to_id_vnet_peering" {
-  source = "github.com/POps-Rox/tf-az-overlays-vnetpeering"
+  source = "github.com/POps-Rox/terraform-az-overlays-vnetpeering"
 
   depends_on = [module.mod_id_network, module.mod_hub_network]
 

--- a/examples/Government/basic_mgt_spoke_cmk/main.tf
+++ b/examples/Government/basic_mgt_spoke_cmk/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_vnet_spoke" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-managementspoke"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-managementspoke"
   #version = "~> x.x.x"
   source = "../../.."
 
@@ -63,7 +63,7 @@ module "mod_vnet_spoke" {
 
 # Create VNet Peering between Hub and Identity VNets
 module "mod_hub_to_id_vnet_peering" {
-  source = "github.com/POps-Rox/tf-az-overlays-vnetpeering"
+  source = "github.com/POps-Rox/terraform-az-overlays-vnetpeering"
 
   location           = var.default_location
   deploy_environment = var.deploy_environment

--- a/modules.management.spoke.diagnostic.setting.tf
+++ b/modules.management.spoke.diagnostic.setting.tf
@@ -14,7 +14,7 @@ AUTHOR/S: jrspinella
 ##############################################
 
 module "mod_vnet_diagnostic_settings" {
-  source = "github.com/POps-Rox/tf-az-overlays-diagnosticsettings"
+  source = "github.com/POps-Rox/terraform-az-overlays-diagnosticsettings"
 
   # Resource Group, location, VNet and Subnet details
   location           = var.location
@@ -28,7 +28,7 @@ module "mod_vnet_diagnostic_settings" {
 }
 
 module "mod_nsg_diagnostic_settings" {
-  source = "github.com/POps-Rox/tf-az-overlays-diagnosticsettings"
+  source = "github.com/POps-Rox/terraform-az-overlays-diagnosticsettings"
 
   for_each = var.spoke_subnets
 

--- a/modules.management.spoke.scaffolding.tf
+++ b/modules.management.spoke.scaffolding.tf
@@ -6,7 +6,7 @@
 #--------------------------------------
 # This module will lookup the Azure Region and return the short name for the region
 module "mod_azregions" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = var.location
 }
@@ -23,7 +23,7 @@ data "azurerm_resource_group" "rgrp" {
 }
 
 module "mod_scaffold_rg" {
-  source = "github.com/POps-Rox/tf-az-overlays-resourcegroup"
+  source = "github.com/POps-Rox/terraform-az-overlays-resourcegroup"
 
   count = var.create_spoke_resource_group ? 1 : 0
 


### PR DESCRIPTION
## Summary
GitHub renamed these repos from `tf-az-overlays-*` to `terraform-az-overlays-*` in a prior cleanup, but module `source =` references in `.tf` files and `catalog-info.yaml` annotations still use the old slug. Terraform module downloads currently succeed only via GitHub's 301 redirect — fragile and prone to break.

## Changes
- All `.tf` files: `POps-Rox/tf-az-overlays-*` → `POps-Rox/terraform-az-overlays-*`
- All `.tf` files: `POps-Rox/tf-az-entra-overlays-*` → `POps-Rox/terraform-az-entra-overlays-*`
- `catalog-info.yaml`: `metadata.name` and `github.com/project-slug` annotation updated to match actual repo name

## Validation
```bash
grep -rln 'POps-Rox/tf-az-overlays\|pops-rox/tf-az-overlays' --include='*.tf' .
grep -l 'tf-az-overlays\|tf-az-entra-overlays' catalog-info.yaml
```
Both return no output after this PR.

Part of the POps-Rox Go-To-Market initiative.